### PR TITLE
Fix bugs with names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sheweny/cli",
-  "version": "1.0.2-beta.2",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sheweny/cli",
-      "version": "1.0.2-beta.2",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "arg": "^5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sheweny/cli",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sheweny/cli",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "arg": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sheweny/cli",
   "description": "Cli for sheweny framework",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "lib/cli.js",
   "bin": {
     "sheweny": "bin/sheweny",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sheweny/cli",
   "description": "Cli for sheweny framework",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": "lib/cli.js",
   "bin": {
     "sheweny": "bin/sheweny",

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -332,9 +332,6 @@ export async function createProject(options: ICreateOptions): Promise<any> {
       title: " 📑 Creating package.json file",
       task: async (ctx, task) => {
         try {
-          // await execa("npm", ["init", "-y"], {
-          //   cwd: options.targetDirectory,
-          // });
           await addInfosPackageJson(options);
         } catch (err) {
           task.skip("An error has occurred");

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,6 +1,6 @@
 import { prompt } from "inquirer";
 import { mkdir, access, readdir, stat, writeFile, readFile } from "fs/promises";
-import { constants, existsSync } from "fs";
+import { constants, exists, existsSync } from "fs";
 import { join, resolve } from "path";
 import { ICreateOptions } from "../typescript/interfaces/interfaces";
 import * as Listr from "listr";
@@ -102,10 +102,7 @@ export async function missingCreateOptions(
 
   return {
     ...options,
-    dirName:
-      options.dirName || answers.dirName
-        ? answers.dirName.replaceAll(" ", "_")
-        : "Bot project",
+    dirName: options.dirName || answers.dirName.replaceAll(" ", "_"),
     template: answers.template.toLowerCase(),
     packageManager: answers.packageManager
       ? answers.packageManager.toLowerCase()
@@ -120,8 +117,14 @@ export async function missingCreateOptions(
 }
 
 async function renameDirName(options: ICreateOptions): Promise<ICreateOptions> {
+  if (options.dirName)
+    options.dirName = options.dirName.replaceAll(
+      /<|>|:|"|\/|\\|\||\?|\*|(^(aux|con|clock|nul|prn|com[1-9]|lpt[1-9])$)/g,
+      ""
+    );
   const pathProject = join(process.cwd(), options.dirName!);
-  if (existsSync(pathProject)) {
+
+  if (existsSync(pathProject) || !options.dirName) {
     const reg = new RegExp(/\_[0-9]{1,2}/);
     const match = options.dirName!.match(reg);
     if (match && match.index === options.dirName!.length - match[0].length) {

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -119,7 +119,7 @@ export async function missingCreateOptions(
 async function renameDirName(options: ICreateOptions): Promise<ICreateOptions> {
   if (options.dirName)
     options.dirName = options.dirName.replaceAll(
-      /<|>|:|"|\/|\\|\||\?|\*|(^(aux|con|clock|nul|prn|com[1-9]|lpt[1-9])$)/g,
+      /<|>|:|"|\/|\\|\||\?|\*|(^(aux|con|clock|nul|prn|com[1-9]|lpt[1-9])$)/gi,
       ""
     );
   const pathProject = join(process.cwd(), options.dirName!);
@@ -220,7 +220,18 @@ async function copyFiles(
 
 async function addInfosPackageJson(options: ICreateOptions): Promise<void> {
   const filePath = join(options.targetDirectory!, "package.json");
-  let file = await import(filePath);
+  let file = {
+    name: options.dirName,
+    version: "1.0.0",
+    description: "",
+    main: "index.js",
+    scripts: {},
+    dependencies: {},
+    devDependencies: {},
+    keywords: [],
+    author: "",
+    license: "ISC",
+  };
   const scriptsJs = options.optionnalLibrary?.includes("nodemon")
     ? {
         start: "node ./src/index.js",
@@ -265,7 +276,7 @@ async function addInfosPackageJson(options: ICreateOptions): Promise<void> {
   file.dependencies = dependencies;
   file.devDependencies =
     options.template === "javascript" ? devDependenciesJs : devDependenciesTs;
-  await writeFile(filePath, JSON.stringify(file, null, 4));
+  await writeFile(filePath, JSON.stringify(file, null, 2));
 }
 
 export async function createProject(options: ICreateOptions): Promise<any> {
@@ -321,9 +332,9 @@ export async function createProject(options: ICreateOptions): Promise<any> {
       title: " 📑 Creating package.json file",
       task: async (ctx, task) => {
         try {
-          await execa("npm", ["init", "-y"], {
-            cwd: options.targetDirectory,
-          });
+          // await execa("npm", ["init", "-y"], {
+          //   cwd: options.targetDirectory,
+          // });
           await addInfosPackageJson(options);
         } catch (err) {
           task.skip("An error has occurred");


### PR DESCRIPTION
Add dirname regex for names that include <>:"/\|?* aux con clock nul prn com[0-9] and lpt[0-9]

Fix bug with name of package.json :
Remove `npm init --yes`
Add package.json default in an object
=> Performances improved and bugs fixes